### PR TITLE
Remove Gradle deprecation

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.nitnelav.pass.to.wallet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
```
package="com.nitnelav.pass.to.wallet" found in source AndroidManifest.xml: /home/project/node_modules/capacitor-pass-to-wallet/android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="com.nitnelav.pass.to.wallet" from the source AndroidManifest.xml: /home/project/node_modules/capacitor-pass-to-wallet/android/src/main/AndroidManifest.xml.

```